### PR TITLE
[FEATURE] Added Support for Language Cateogies.

### DIFF
--- a/src/app/api/scrape/route.js
+++ b/src/app/api/scrape/route.js
@@ -1,8 +1,8 @@
 import { scrapeCodeforcesProblemStatus } from '../../../utils/scrapper';
 
 export async function POST(req) {
-  const { url, category, language } = await req.json();
-
+  const { url, category,language } = await req.json();
+  
   if (!url) {
     return new Response(JSON.stringify({ error: 'URL is required' }), {
       status: 400,
@@ -37,7 +37,7 @@ export async function POST(req) {
   }
 
   try {
-    const data = await scrapeCodeforcesProblemStatus(url, category, language);
+    const data = await scrapeCodeforcesProblemStatus(url,category,language);
 
     return new Response(JSON.stringify({ data }), {
       status: 200,

--- a/src/app/api/scrape/route.js
+++ b/src/app/api/scrape/route.js
@@ -1,8 +1,8 @@
 import { scrapeCodeforcesProblemStatus } from '../../../utils/scrapper';
 
 export async function POST(req) {
-  const { url, category, languageList} = await req.json();
-  
+  const { url, category, language } = await req.json();
+
   if (!url) {
     return new Response(JSON.stringify({ error: 'URL is required' }), {
       status: 400,
@@ -17,7 +17,7 @@ export async function POST(req) {
     });
   }
 
-  if (!languageList) {
+  if (!language) {
     return new Response(JSON.stringify({ error: 'Language is required' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
@@ -37,7 +37,7 @@ export async function POST(req) {
   }
 
   try {
-    const data = await scrapeCodeforcesProblemStatus(url,category,languageList);
+    const data = await scrapeCodeforcesProblemStatus(url, category, language);
 
     return new Response(JSON.stringify({ data }), {
       status: 200,

--- a/src/app/api/scrape/route.js
+++ b/src/app/api/scrape/route.js
@@ -1,7 +1,7 @@
 import { scrapeCodeforcesProblemStatus } from '../../../utils/scrapper';
 
 export async function POST(req) {
-  const { url, category,language } = await req.json();
+  const { url, category, languageList} = await req.json();
   
   if (!url) {
     return new Response(JSON.stringify({ error: 'URL is required' }), {
@@ -17,7 +17,7 @@ export async function POST(req) {
     });
   }
 
-  if (!language) {
+  if (!languageList) {
     return new Response(JSON.stringify({ error: 'Language is required' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
@@ -37,7 +37,7 @@ export async function POST(req) {
   }
 
   try {
-    const data = await scrapeCodeforcesProblemStatus(url,category,language);
+    const data = await scrapeCodeforcesProblemStatus(url,category,languageList);
 
     return new Response(JSON.stringify({ data }), {
       status: 200,

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -31,10 +31,11 @@ export default function Home() {
   ];
 
   const languageCategories = {
-    PyPy: ["PyPy 3-64", "PyPy 3"],
-    "C++": ["C++17 (GCC 7-32)", "C++14 (GCC 6-32)", "C++20 (GCC 13-64)"],
-    Python: ["Python 3"],
-    Java: ["Java 21"],
+    C: ["GNU C11"],
+    "Python/PyPy": ["Python 2", "Python 3", "PyPy 2", "PyPy 3", "PyPy 3-64"],
+    "C++": ["C++14 (GCC 6-32)", "C++17 (GCC 7-32)", "C++20 (GCC 13-64)", "C++23 (GCC 14-64, msys2)"],
+    Java: ["Java 6", "Java 7", "Java 8", "Java 21"],
+    Kotlin: ["Kotlin 1.7", "Kotlin 1.9", "Kotlin 2.2"],
     JavaScript: ["JavaScript"]
   };
 

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -171,7 +171,7 @@ export default function Home() {
         <select
           value={category}
           onChange={(e) => setCategory(e.target.value)}
-          className="w-full h-12 px-4 py-2 pr-8 text-black border border-gray-300 rounded-lg mb-4"
+          className="w-full h-12 px-4 py-2 pr-8 text-black border border-gray-300 rounded-lg mb-4 "
           required
         >
           <option value="">Select Category</option>
@@ -212,7 +212,7 @@ export default function Home() {
             ${isDarkMode? "bg-gray-800":"bg-white"}`}>
             {result.length > 0 ? (
               <div>
-                <div className={`mb-2 ${isDarkMode ? "text-white" : "text-black"}`}>
+                <div className={`mb-2 ${isDarkMode? "text-white": "text-black"}`}>
                   <strong>Author:</strong> {result[0].author}
                 </div>
                 <div className="mb-2">
@@ -220,7 +220,7 @@ export default function Home() {
                     href={result[0].submission}
                     target="_blank"
                     rel="noreferrer"
-                    className={` underline ${isDarkMode ? "text-blue-500" : "text-blue-700"}`}
+                    className={` underline ${isDarkMode? "text-blue-500": "text-blue-700"}`}
                   >
                     View Submission
                   </a>
@@ -228,7 +228,7 @@ export default function Home() {
                 <div className="mb-2">
                   <button
                     onClick={handleExplainClick}
-                    className={` underline bg-transparent border-none cursor-pointer ${isDarkMode ? "text-blue-500 " : "text-blue-700"}`}
+                    className={` underline bg-transparent border-none cursor-pointer ${isDarkMode? "text-blue-500 ": "text-blue-700"}`}
                   >
                     View the Code
                   </button>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { parseStream } from "@/utils/streaming";
-import ThemeToggler from "@/components/themetoggler";
-import Image from 'next/image';
+import ThemeToggler from "@/components/themetoggler"; 
+import { categories, languages } from "../utils/constants";
 
 export default function Home() {
   const [isDarkMode, setIsDarkMode] = useState(true); 
@@ -16,28 +16,6 @@ export default function Home() {
   const [explanation, setExplanation] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
-
-  const categories = [
-    "newbie",
-    "pupil",
-    "specialist",
-    "expert",
-    "candidate master",
-    "master",
-    "international master",
-    "grandmaster",
-    "international grandmaster",
-    "legendary grandmaster",
-  ];
-
-  const languageCategories = {
-    C: ["GNU C11"],
-    "Python/PyPy": ["Python 2", "Python 3", "PyPy 2", "PyPy 3", "PyPy 3-64"],
-    "C++": ["C++14 (GCC 6-32)", "C++17 (GCC 7-32)", "C++20 (GCC 13-64)", "C++23 (GCC 14-64, msys2)"],
-    Java: ["Java 6", "Java 7", "Java 8", "Java 21"],
-    Kotlin: ["Kotlin 1.7", "Kotlin 1.9", "Kotlin 2.2"],
-    JavaScript: ["JavaScript"]
-  };
 
   const maneesh = async () => {
     const sc = sourceCode;

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { parseStream } from "@/utils/streaming";
 import ThemeToggler from "@/components/themetoggler"; 
-import { categories, languages } from "../utils/constants";
+import { categories, languageCategories } from "../utils/constants";
 
 export default function Home() {
   const [isDarkMode, setIsDarkMode] = useState(true); 

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -2,14 +2,15 @@
 
 import { useState, useEffect } from "react";
 import { parseStream } from "@/utils/streaming";
-import ThemeToggler from "@/components/themetoggler"; 
+import ThemeToggler from "@/components/themetoggler";
+import Image from 'next/image';
 
 export default function Home() {
   const [isDarkMode, setIsDarkMode] = useState(true); 
   const [contestID, setContestID] = useState("");
   const [problemIndex, setProblemIndex] = useState("");
   const [category, setCategory] = useState("");
-  const [language, setLanguage] = useState("");
+  const [baseLanguage, setBaseLanguage] = useState("");
   const [result, setResult] = useState(null);
   const [sourceCode, setSourceCode] = useState("");
   const [explanation, setExplanation] = useState("");
@@ -29,16 +30,13 @@ export default function Home() {
     "legendary grandmaster",
   ];
 
-  const languages = [
-    "PyPy 3-64",
-    "C++17 (GCC 7-32)",
-    "Python 3",
-    "PyPy 3",
-    "C++14 (GCC 6-32)",
-    "C++20 (GCC 13-64)",
-    "Java 21",
-    "JavaScript",
-  ];
+  const languageCategories = {
+    PyPy: ["PyPy 3-64", "PyPy 3"],
+    "C++": ["C++17 (GCC 7-32)", "C++14 (GCC 6-32)", "C++20 (GCC 13-64)"],
+    Python: ["Python 3"],
+    Java: ["Java 21"],
+    JavaScript: ["JavaScript"]
+  };
 
   const maneesh = async () => {
     const sc = sourceCode;
@@ -81,12 +79,14 @@ export default function Home() {
     const url = `https://codeforces.com/problemset/status/${contestID}/problem/${problemIndex}`;
 
     try {
+      const selectedLanguages = languageCategories[baseLanguage] || []; // baseLanguage is a string like "C++" or "Python" (a valid key from languageCategories)
+
       const response = await fetch("/api/scrape", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ url, category, language }),
+        body: JSON.stringify({ url, category, languageList: selectedLanguages }),
       });
 
       const data = await response.json();
@@ -192,7 +192,7 @@ export default function Home() {
         <select
           value={category}
           onChange={(e) => setCategory(e.target.value)}
-          className="w-full h-12 px-4 py-2 pr-8 text-black border border-gray-300 rounded-lg mb-4 "
+          className="w-full h-12 px-4 py-2 pr-8 text-black border border-gray-300 rounded-lg mb-4"
           required
         >
           <option value="">Select Category</option>
@@ -203,15 +203,15 @@ export default function Home() {
           ))}
         </select>
         <select
-          value={language}
-          onChange={(e) => setLanguage(e.target.value)}
+          value={baseLanguage}
+          onChange={(e) => setBaseLanguage(e.target.value)}
           className="w-full h-12 px-4 py-2 pr-8 text-black border border-gray-300 rounded-lg mb-4"
           required
         >
           <option value="">Select Language</option>
-          {languages.map((lang) => (
-            <option key={lang} value={lang}>
-              {lang}
+          {Object.keys(languageCategories).map((baseLang) => (
+            <option key={baseLang} value={baseLang}>
+              {baseLang}
             </option>
           ))}
         </select>
@@ -233,7 +233,7 @@ export default function Home() {
             ${isDarkMode? "bg-gray-800":"bg-white"}`}>
             {result.length > 0 ? (
               <div>
-                <div className={`mb-2 ${isDarkMode? "text-white": "text-black"}`}>
+                <div className={`mb-2 ${isDarkMode ? "text-white" : "text-black"}`}>
                   <strong>Author:</strong> {result[0].author}
                 </div>
                 <div className="mb-2">
@@ -241,7 +241,7 @@ export default function Home() {
                     href={result[0].submission}
                     target="_blank"
                     rel="noreferrer"
-                    className={` underline ${isDarkMode? "text-blue-500": "text-blue-700"}`}
+                    className={` underline ${isDarkMode ? "text-blue-500" : "text-blue-700"}`}
                   >
                     View Submission
                   </a>
@@ -249,7 +249,7 @@ export default function Home() {
                 <div className="mb-2">
                   <button
                     onClick={handleExplainClick}
-                    className={` underline bg-transparent border-none cursor-pointer ${isDarkMode? "text-blue-500 ": "text-blue-700"}`}
+                    className={` underline bg-transparent border-none cursor-pointer ${isDarkMode ? "text-blue-500 " : "text-blue-700"}`}
                   >
                     View the Code
                   </button>

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,24 @@
+export const categories = [
+    "pupil",
+    "newbie",
+    "specialist",
+    "expert",
+    "candidate master",
+    "master",
+    "international master",
+    "grandmaster",
+    "international grandmaster",
+    "legendary grandmaster",
+  ];
+
+export const languages = [
+    "PyPy 3-64",
+    "C++17 (GCC 7-32)",
+    "Python 3",
+    "PyPy 3",
+    "C++14 (GCC 6-32)",
+    "C++20 (GCC 13-64)",
+    "Java 21",
+    "JavaScript",
+  ];
+  

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -11,14 +11,12 @@ export const categories = [
     "legendary grandmaster",
   ];
 
-export const languages = [
-    "PyPy 3-64",
-    "C++17 (GCC 7-32)",
-    "Python 3",
-    "PyPy 3",
-    "C++14 (GCC 6-32)",
-    "C++20 (GCC 13-64)",
-    "Java 21",
-    "JavaScript",
-  ];
+export const languageCategories = {
+    C: ["GNU C11"],
+    "Python/PyPy": ["Python 2", "Python 3", "PyPy 2", "PyPy 3", "PyPy 3-64"],
+    "C++": ["C++14 (GCC 6-32)", "C++17 (GCC 7-32)", "C++20 (GCC 13-64)", "C++23 (GCC 14-64, msys2)"],
+    Java: ["Java 6", "Java 7", "Java 8", "Java 21"],
+    Kotlin: ["Kotlin 1.7", "Kotlin 1.9", "Kotlin 2.2"],
+    JavaScript: ["JavaScript"]
+  };
   

--- a/src/utils/scrapper.js
+++ b/src/utils/scrapper.js
@@ -1,8 +1,8 @@
 import axios from "axios";
 import { load } from "cheerio"; // Import load function directly
 
-const scrapeCodeforcesProblemStatus = async (url, category, language) => {
-  console.log("lang", language);
+const scrapeCodeforcesProblemStatus = async (url, category, languageList) => {
+  console.log("languages:", languageList);
   const categories = [category];
 
   try {
@@ -44,7 +44,7 @@ const scrapeCodeforcesProblemStatus = async (url, category, language) => {
             !submissions[authorFirstWord] &&
             categories.includes(authorFirstWord) &&
             verdict === "Accepted" &&
-            lang === language
+            languageList.includes(lang) // lang can be any language in the selected Language Category List (Ex. "C++"/"Python"/etc.)
           ) {
             submissions[authorFirstWord] = {
               submission: `https://codeforces.com/contest/${url.split("/")[5]}/submission/${submissionId}`,


### PR DESCRIPTION
Resolves #39.

The proposed feature is implemented.

**Implementation Overview:**
- The languages corresponding to a category (Ex. ```C++```) can be stored as a list.
- This list of languages corresponding to selected category can be passed into the API.
- Scrape a submission if its language is in the language list for the desired category.

**Tests:**
- The list of languages at each scrape request is logged correctly.
Ex. `languages: [ 'C++17 (GCC 7-32)', 'C++14 (GCC 6-32)', 'C++20 (GCC 13-64)' ]`
- All the required changes in [page.js](https://github.com/shuklamaneesh23/cf_helper/blob/master/src/app/page.js), [route.js](https://github.com/shuklamaneesh23/cf_helper/blob/master/src/app/api/scrape/route.js) and [scrapper.js](https://github.com/shuklamaneesh23/cf_helper/blob/master/src/utils/scrapper.js).